### PR TITLE
Use native linux binary.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,19 @@
 FROM docker.io/debian:bookworm
 
-#Install Misc
+#Install dependencies (One line, to minimize size)
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
-    && apt-get install procps wget iproute2 isc-dhcp-client inetutils-ping inetutils-traceroute xterm -y \
-    && rm -rf /var/lib/apt/lists/*
-
-#Intall Wine (https://wiki.winehq.org/Debian)
-RUN dpkg --add-architecture i386
-RUN mkdir -pm755 /etc/apt/keyrings
-RUN wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
-RUN wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/debian/dists/bookworm/winehq-bookworm.sources
-RUN DEBIAN_FRONTEND=noninteractive apt-get update \
-    && apt-get install --install-recommends winehq-stable -y \
-    && rm -rf /var/lib/apt/lists/*
-
-#Install WM
-RUN DEBIAN_FRONTEND=noninteractive apt-get update \
-    && apt-get install openbox -y \
-    && rm -rf /var/lib/apt/lists/*
-
-#Install VNC
-RUN DEBIAN_FRONTEND=noninteractive apt-get update \
-    && apt-get install x11-utils x11vnc xvfb -y \
-    && rm -rf /var/lib/apt/lists/*
-
-#Preconfigure Wine
-RUN winecfg
-
-#Copy in entrypoint script and WinBox license
-WORKDIR /
-COPY ./entrypoint.sh /entrypoint.sh
-COPY ./WINBOX_LICENSE /WINBOX_LICENSE
+    && apt-get install -y procps wget unzip iproute2 isc-dhcp-client inetutils-ping inetutils-traceroute xterm openbox x11-utils x11vnc xvfb libegl1 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0-dev autocutsel \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 #Download WinBox
 #Permission has been granted by Mikrotik (via support@mikrotik.com, ticket number #[SUP-114983]) to distribute WinBox unmodified within this image.
-RUN wget -O /winbox64.exe https://download.mikrotik.com/routeros/winbox/3.41/winbox64.exe
+RUN wget -O /tmp/winbox.zip https://download.mikrotik.com/routeros/winbox/4.0beta18/WinBox_Linux.zip && unzip /tmp/winbox.zip -d / && rm /tmp/winbox.zip
+
+#Copy in entrypoint script and WinBox license
+WORKDIR /
+COPY ./entrypoint.sh ./WINBOX_LICENSE /
+# Create directories and edit OpenBox config to launch maximized
+RUN mkdir -p /root/.local/share/MikroTik/WinBox/workspaces/ && sed -i 's#</applications>#<application class="*"><maximized>yes</maximized></application></applications>#' /etc/xdg/openbox/rc.xml
 
 #Finalise
 EXPOSE 5900

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ WORKDIR /
 COPY ./entrypoint.sh ./WINBOX_LICENSE /
 # Create directories and edit OpenBox config to launch maximized
 RUN mkdir -p /root/.local/share/MikroTik/WinBox/workspaces/ && sed -i 's#</applications>#<application class="*"><maximized>yes</maximized></application></applications>#' /etc/xdg/openbox/rc.xml
+VOLUME /root/.local/share/MikroTik/
 
 #Finalise
 EXPOSE 5900

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
 
 #Download WinBox
 #Permission has been granted by Mikrotik (via support@mikrotik.com, ticket number #[SUP-114983]) to distribute WinBox unmodified within this image.
-RUN wget -O /tmp/winbox.zip https://download.mikrotik.com/routeros/winbox/4.0beta18/WinBox_Linux.zip && unzip /tmp/winbox.zip -d / && rm /tmp/winbox.zip
+RUN wget -O /tmp/winbox.zip https://download.mikrotik.com/routeros/winbox/4.0beta20/WinBox_Linux.zip && unzip /tmp/winbox.zip -d / && rm /tmp/winbox.zip
 
 #Copy in entrypoint script and WinBox license
 WORKDIR /

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) 2025 Atis https://github.com/atis
 Copyright (c) 2023 Alexander Horner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # WinBox Dockerised
-A simple container which runs Mikrotik's WinBox64 via OpenBox and x11vnc, served via VNC on port 5900
+A simple container which runs Mikrotik's WinBox via OpenBox and x11vnc, served via VNC on port 5900
 
 The purpose of this container is to provide a simple WinBox instance which can be run standalone, but is also fully compatible with GNS3 (it can be imported in and used with GNS3's VNC mode)
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,11 +11,12 @@ if [ "${VNC_BUILTIN_DISABLED}" = true ]; then
     echo "Using display ${DISPLAY}"
 else
     echo "Builtin VNC is enabled. The DISPLAY variable will be ignored and overwritten"
-    export DISPLAY=":0"
+    export DISPLAY=":10"
 
     #Launch the virtual framebuffer and wait for it to become ready
     echo "Using display ${DISPLAY} with size of ${VNC_BUILTIN_WIDTH}x${VNC_BUILTIN_HEIGHT} with pixel depth ${VNC_BUILTIN_PIXELDEPTH}"
-    Xvfb ${DISPLAY} -screen 0 "${VNC_BUILTIN_WIDTH}x${VNC_BUILTIN_HEIGHT}x${VNC_BUILTIN_PIXELDEPTH}" &
+    echo "Xvfb ${DISPLAY} -nolisten tcp -screen 0 "${VNC_BUILTIN_WIDTH}x${VNC_BUILTIN_HEIGHT}x${VNC_BUILTIN_PIXELDEPTH}" "
+    Xvfb ${DISPLAY} -nolisten tcp -screen 0 "${VNC_BUILTIN_WIDTH}x${VNC_BUILTIN_HEIGHT}x${VNC_BUILTIN_PIXELDEPTH}" &
 fi
 
 #Wait for the display to become ready
@@ -32,16 +33,19 @@ done
 
 #Launch the VNC server if enabled
 if [ "${VNC_BUILTIN_DISABLED}" != true ]; then
+    # Enable copy-paste for VNC
+    export XKL_XMODMAP_DISABLE=1
+    autocutsel -fork -s PRIMARY &
+    
     x11vnc -bg -forever -nopw -display ${DISPLAY} &
 fi
 
 #Launch OpenBox
-openbox &
+openbox --sm-disable &
 
 #Launch WinBox
 while true
 do
-    if [[ ! $(pgrep wine) ]]; then
-        wine64 /winbox64.exe
-    fi
+    /WinBox
+    sleep 1
 done


### PR DESCRIPTION
Use native linux binary.
Bump version to 4.x
Launch maximized
Fix VNC clipboard
Change default display to :10, as :0 is problematic to use with host-networking

These are some major changes, not sure if you want to merge or keep wine version. 